### PR TITLE
move auth to czi-id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,24 @@ install:
 - pip install nose requests ecs-deploy flake8
 - curl -o $HOME/bin/docker-helper https://raw.githubusercontent.com/chanzuckerberg/infra-tools/6402865/docker-helper
 - chmod +x $HOME/bin/docker-helper
+before_script:
+  - set -eo pipefail
+  - aws configure set aws_access_key_id     $CZIIAM_AWS_ACCESS_KEY_ID     --profile czi-id
+  - aws configure set aws_secret_access_key $CZIIAM_AWS_SECRET_ACCESS_KEY --profile czi-id
+  - aws --profile czi-id sts get-caller-identity
+
+  - aws configure set profile.czi-legacy.role_arn arn:aws:iam::787588439240:role/cellxgene-travis-ci
+  - aws configure set profile.czi-legacy.source_profile czi-id
+  - aws --profile czi sts get-caller-identity
+
 script:
 - set -eo pipefail
 - flake8 .
 - docker-helper build chanzuckerberg/cellxgene-rest-api . $TRAVIS_BRANCH ${TRAVIS_COMMIT::8} $TRAVIS_BUILD_NUMBER
 - |
-  docker run -d -p 5000:5000 --name cxg -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION \
-  -e AWS_REGION=$AWS_DEFAULT_REGION -e CONFIG_FILE -e CXG_API_BASE -e ENV=ci chanzuckerberg/cellxgene-rest-api:ci
+  docker run -d -p 5000:5000 --name cxg -e HOME=/home -v $$HOME/.aws:/home/.aws -e AWS_DEFAULT_REGION \
+  -e AWS_PROFILE=czi-legacy -e AWS_REGION=$AWS_DEFAULT_REGION -e CONFIG_FILE -e CXG_API_BASE -e ENV=ci \
+  chanzuckerberg/cellxgene-rest-api:ci
 - for i in {1..90}; do if http :5000/api/v0.1/initialize > /dev/null; then break; else echo "Waiting for server..."; sleep 1; fi; done
 - if ! http :5000/api/v0.1/initialize > /dev/null; then echo `docker logs cxg`; exit 1; fi;
 - nosetests tests/test_api.py
@@ -35,16 +46,16 @@ after_success:
 deploy:
 - provider: script
   script:
-  - ecs deploy stp-staging stp-staging-cellxgene-rest-api --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  - ecs deploy --profile czi-legacy stp-staging stp-staging-cellxgene-rest-api --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
   on:
     branch: master
 - provider: script
   script:
-  - ecs deploy stp-staging stp-staging-cxg-rest-api-mouse --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  - ecs deploy --profile czi-legacy stp-staging stp-staging-cxg-rest-api-mouse --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
   on:
     branch: production
 - provider: script
   script:
-  - ecs deploy stp-staging cxg-rest-api-pbmc3k-staging --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  - ecs deploy --profile czi-legacy stp-staging cxg-rest-api-pbmc3k-staging --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
   on:
     branch: hinxton

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
   - aws configure set profile.czi-legacy.role_arn arn:aws:iam::787588439240:role/cellxgene-travis-ci
   - aws configure set profile.czi-legacy.source_profile czi-id
-  - aws --profile czi sts get-caller-identity
+  - aws --profile czi-legacy sts get-caller-identity
 
 script:
 - set -eo pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 - flake8 .
 - docker-helper build chanzuckerberg/cellxgene-rest-api . $TRAVIS_BRANCH ${TRAVIS_COMMIT::8} $TRAVIS_BUILD_NUMBER
 - |
-  docker run -d -p 5000:5000 --name cxg -e HOME=/home -v $$HOME/.aws:/home/.aws -e AWS_DEFAULT_REGION \
+  docker run -d -p 5000:5000 --name cxg -e HOME=/home -v $HOME/.aws:/home/.aws -e AWS_DEFAULT_REGION \
   -e AWS_PROFILE=czi-legacy -e AWS_REGION=$AWS_DEFAULT_REGION -e CONFIG_FILE -e CXG_API_BASE -e ENV=ci \
   chanzuckerberg/cellxgene-rest-api:ci
 - for i in {1..90}; do if http :5000/api/v0.1/initialize > /dev/null; then break; else echo "Waiting for server..."; sleep 1; fi; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 - flake8 .
 - docker-helper build chanzuckerberg/cellxgene-rest-api . $TRAVIS_BRANCH ${TRAVIS_COMMIT::8} $TRAVIS_BUILD_NUMBER
 - |
-  docker run -d -p 5000:5000 --name cxg -e HOME=/home -v $HOME/.aws:/home/.aws -e AWS_DEFAULT_REGION \
+  docker run -d -p 5000:5000 --name cxg -v $HOME/.aws:/root/.aws -e AWS_DEFAULT_REGION \
   -e AWS_PROFILE=czi-legacy -e AWS_REGION=$AWS_DEFAULT_REGION -e CONFIG_FILE -e CXG_API_BASE -e ENV=ci \
   chanzuckerberg/cellxgene-rest-api:ci
 - for i in {1..90}; do if http :5000/api/v0.1/initialize > /dev/null; then break; else echo "Waiting for server..."; sleep 1; fi; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - echo
 install:
 - set -eo pipefail
-- pip install nose requests ecs-deploy flake8
+- pip install nose requests ecs-deploy flake8 awscli
 - curl -o $HOME/bin/docker-helper https://raw.githubusercontent.com/chanzuckerberg/infra-tools/6402865/docker-helper
 - chmod +x $HOME/bin/docker-helper
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
 - chmod +x $HOME/bin/docker-helper
 before_script:
   - set -eo pipefail
-  - aws configure set aws_access_key_id     $CZIIAM_AWS_ACCESS_KEY_ID     --profile czi-id
-  - aws configure set aws_secret_access_key $CZIIAM_AWS_SECRET_ACCESS_KEY --profile czi-id
+  - aws configure set aws_access_key_id     $CZIID_AWS_ACCESS_KEY_ID     --profile czi-id
+  - aws configure set aws_secret_access_key $CZIID_AWS_SECRET_ACCESS_KEY --profile czi-id
   - aws --profile czi-id sts get-caller-identity
 
   - aws configure set profile.czi-legacy.role_arn arn:aws:iam::787588439240:role/cellxgene-travis-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ EXPOSE 5000:5000
 ADD https://github.com/segmentio/chamber/releases/download/v1.16.0/chamber-v1.16.0-linux-amd64 /bin/chamber
 RUN chmod +x /bin/chamber
 
+ENV AWS_SDK_LOAD_CONFIG=1
+
 CMD chamber exec stp-$ENV-cellxgene -- python3 application.py


### PR DESCRIPTION
I can explain more later f2f, but this change moves auth for the CI user to the new AWS account.

I have not tested the deploys part of the job yet, because I don't want to stomp on anything.