### PR TITLE
Egress

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -112,12 +112,16 @@ class EndPoints(unittest.TestCase):
             ["Selection=Unpanned", "ERCC_reads=150000,200000"]))
         result = self.session.get(url)
         assert result.status_code == 200
+        assert result.headers['Content-Type'].startswith("text/csv")
+        assert len(result.text) > 0
 
     def test_metadatadownload(self):
         url = "{base}{endpoint}?{params}".format(base=self.url_base, endpoint="metadatadownload", params="&".join(
             ["Selection=Unpanned", "ERCC_reads=150000,200000"]))
         result = self.session.get(url)
         assert result.status_code == 200
+        assert result.headers['Content-Type'].startswith("text/csv")
+        assert len(result.text) > 0
 
     def test_cells_failure(self):
         url = "{base}{endpoint}?{params}".format(base=self.url_base, endpoint="cells", params="&".join(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,8 +103,21 @@ class EndPoints(unittest.TestCase):
             ["Selection=Unpanned", "ERCC_reads=150000,200000", "_nograph=True"]))
         result = self.session.get(url)
         result_json = result.json()
+        print(result_json)
         assert result.status_code == 200
         assert result_json["data"]["graph"] is None
+
+    def test_download(self):
+        url = "{base}{endpoint}?{params}".format(base=self.url_base, endpoint="download", params="&".join(
+            ["Selection=Unpanned", "ERCC_reads=150000,200000"]))
+        result = self.session.get(url)
+        assert result.status_code == 200
+
+    def test_metadatadownload(self):
+        url = "{base}{endpoint}?{params}".format(base=self.url_base, endpoint="metadatadownload", params="&".join(
+            ["Selection=Unpanned", "ERCC_reads=150000,200000"]))
+        result = self.session.get(url)
+        assert result.status_code == 200
 
     def test_cells_failure(self):
         url = "{base}{endpoint}?{params}".format(base=self.url_base, endpoint="cells", params="&".join(


### PR DESCRIPTION
Put the csv writer back in to reliably escape values for csv writing. Did testing on a 10k x 10k matrix file and this (truncating the stringio object as opposed to recreating the csv writer each time) was the fastest