### PR TITLE
Deploy cellxgene using czecs, upgrade chamber, use new role names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,9 @@ addons:
     - gettext
     - curl
     - httpie
-before_install:
-  - echo
 install:
 - set -eo pipefail
-- pip install nose requests ecs-deploy flake8 awscli
+- pip install nose requests flake8 awscli
 - curl -o $HOME/bin/docker-helper https://raw.githubusercontent.com/chanzuckerberg/infra-tools/6402865/docker-helper
 - chmod +x $HOME/bin/docker-helper
 before_script:
@@ -43,34 +41,31 @@ after_success:
 - set -eo pipefail
 - bash <(curl -s https://codecov.io/bash)
 - docker-helper push chanzuckerberg/cellxgene-rest-api
+before_deploy:
+- curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.0.1/czecs_0.0.1_linux_amd64.tar.gz | tar xz -C $HOME/bin czecs
 deploy:
 - provider: script
-  script:
-  - ecs deploy --profile czi-legacy stp-staging stp-staging-cellxgene-rest-api --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cellxgene-rest-api stp-staging stp-staging-cellxgene-rest-api czecs.json
   on:
     branch: master
 - provider: script
-  script:
-  - ecs deploy --profile czi-legacy stp-staging stp-staging-cxg-rest-api-mouse --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-mouse stp-staging stp-staging-cxg-rest-api-mouse czecs.json
   on:
     branch: production
 - provider: script
-  script:
-  - ecs deploy --profile czi-legacy stp-staging cxg-rest-api-pbmc3k-staging --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-pbmc3k stp-staging stp-staging-cxg-rest-api-pbmc3k czecs.json
   on:
     branch: hinxton
 - provider: script
-  script:
-  - ecs deploy --profile czi-legacy stp-staging stp-staging-cxg-rest-api-biopsy --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-biopsy stp-staging stp-staging-cxg-rest-api-biopsy czecs.json
   on:
     branch: biopsy
 - provider: script
-  script:
-  - ecs deploy --profile czi-legacy stp-staging stp-staging-cxg-rest-api-kidney --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-kidney stp-staging stp-staging-cxg-rest-api-kidney czecs.json
   on:
     branch: humankidney
+# TODO(mbarrien): hopkins? pbmc33k?
 - provider: script
-  script:
-  - ecs deploy --profile czi-legacy stp-staging stp-staging-cxg-rest-api-hopkins --timeout 10000 --tag sha-${TRAVIS_COMMIT::8}
+  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-hopkins stp-staging stp-staging-cxg-rest-api-hopkins czecs.json
   on:
     branch: mouseretina

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM csweaver/cellxgene
 
 # Env vars expected when running containers from this image:
 # * ENV - staging, etc.
-# * CXG_API_BASE
-# * CONFIG_FILE
+# * SERVICE
 
 # It also needs to be able to authenticate to AWS. In ECS this will come in the form of a
 # task profile. When running elsewhere you should pass in some credentials via environment
@@ -25,9 +24,9 @@ EXPOSE 5000:5000
 
 # Install chamber, for pulling secrets into the container.
 # Needs a `secret_key` setting.
-ADD https://github.com/segmentio/chamber/releases/download/v1.16.0/chamber-v1.16.0-linux-amd64 /bin/chamber
+ADD https://github.com/segmentio/chamber/releases/download/v2.1.0/chamber-v2.1.0-linux-amd64 /bin/chamber
 RUN chmod +x /bin/chamber
 
 ENV AWS_SDK_LOAD_CONFIG=1
 
-CMD chamber exec stp-$ENV-cellxgene -- chamber exec stp-$ENV-$SERVICE -- python3 application.py
+CMD chamber exec stp-$ENV-cellxgene stp-$ENV-$SERVICE -- python3 application.py

--- a/balances.json
+++ b/balances.json
@@ -1,0 +1,7 @@
+{
+  "region": "us-east-1",
+  "project": "stp",
+  "env": "staging",
+  "tag": "branch-master"
+}
+

--- a/czecs.json
+++ b/czecs.json
@@ -1,0 +1,33 @@
+{
+  "Family": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}",
+  "ContainerDefinitions": [
+    {
+      "name": "cellxgene-rest-api",
+      "image": "chanzuckerberg/cellxgene-rest-api:{{ .Values.tag }}",
+      "cpu": 1024,
+      "memoryReservation": 4096,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 5000,
+          "hostPort": 0
+        }
+      ],
+      "environment": [
+        { "name": "AWS_REGION",           "value": "{{ .Values.region }}" },
+        { "name": "AWS_DEFAULT_REGION",   "value": "{{ .Values.region }}" },
+        { "name": "ENV",                  "value": "{{ .Values.env }}" },
+        { "name": "SERVICE",              "value": "{{ .Values.name }}"}
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "stp-ecs-logs-{{ .Values.env }}",
+          "awslogs-region": "{{ .Values.region }}",
+          "awslogs-stream-prefix": "cellxgene-rest-api"
+        }
+      }
+    }
+  ],
+  "TaskRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}"
+}


### PR DESCRIPTION
This PR changes cellxgene-rest-api to use [https://github.com/chanzuckerberg/czecs](czecs) instead of fabfuel/ecs-deploy. This PR is paired with <https://github.com/chanzuckerberg/stp-infra/pull/47>.

czecs puts the definition of the task definition into the code repos, no longer requiring Terraform to pre-define the task. (See other PR for more details.) This PR includes the task definition, which is a template where some of the values are defined via the included balances.json file, or via command line overrides as seen in .travis.yml.

There is an upgrade to chamber to 2.x series in the PR. In Chamber 2.x, the naming scheme now defaults to using '/' slash separators instead of '.' dots. I have migrated the existing Parameter Store names to use slashes as well; both names are valid for now, but once this is merged and widely deployed, I'd like to manually remove the dot-separated names.

Note that the TaskRoleArn now matches the preferred project-env-service naming scheme, and thus requires the other PR to be deployed before this one can be used.