### PR TITLE
Remove pbmc3k from travis.yml deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ after_success:
 - bash <(curl -s https://codecov.io/bash)
 - docker-helper push chanzuckerberg/cellxgene-rest-api
 before_deploy:
-- curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.0.1/czecs_0.0.1_linux_amd64.tar.gz | tar xz -C $HOME/bin czecs
+- curl -L https://github.com/chanzuckerberg/czecs/releases/download/v0.0.2/czecs_0.0.2_linux_amd64.tar.gz | tar xz -C $HOME/bin czecs
 deploy:
 - provider: script
   script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cellxgene-rest-api stp-staging stp-staging-cellxgene-rest-api czecs.json
@@ -53,10 +53,6 @@ deploy:
   on:
     branch: production
 - provider: script
-  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-pbmc3k stp-staging stp-staging-cxg-rest-api-pbmc3k czecs.json
-  on:
-    branch: hinxton
-- provider: script
   script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-biopsy stp-staging stp-staging-cxg-rest-api-biopsy czecs.json
   on:
     branch: biopsy
@@ -64,8 +60,3 @@ deploy:
   script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-kidney stp-staging stp-staging-cxg-rest-api-kidney czecs.json
   on:
     branch: humankidney
-# TODO(mbarrien): hopkins? pbmc33k?
-- provider: script
-  script: AWS_PROFILE=czi-legacy czecs upgrade --balances balances.json --set tag=sha-${TRAVIS_COMMIT::8} --set name=cxg-rest-api-hopkins stp-staging stp-staging-cxg-rest-api-hopkins czecs.json
-  on:
-    branch: mouseretina

--- a/czecs.json
+++ b/czecs.json
@@ -22,7 +22,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "stp-ecs-logs-{{ .Values.env }}",
+          "awslogs-group": "stp-{{ .Values.env }}-ecs",
           "awslogs-region": "{{ .Values.region }}",
           "awslogs-stream-prefix": "cellxgene-rest-api"
         }


### PR DESCRIPTION
This PR removes pbmc3k auto-deploying on the hinxton branch, now that pbmc3k is removed from ECS. It also removes the autodeploy of the mouseretina branch onto the hopkins ECS task, because the hopkins ECS task does not exist.