### PR TITLE
Use fargate for cellxgene deployments

### DIFF
--- a/balances.json
+++ b/balances.json
@@ -2,6 +2,7 @@
   "region": "us-east-1",
   "project": "stp",
   "env": "staging",
-  "tag": "branch-master"
+  "tag": "branch-master",
+  "repo_credentials": "arn:aws:secretsmanager:us-west-2:787588439240:secret:shared-infra-staging-credentials/dockerhub-czisi-PhEla6"
 }
 

--- a/balances.json
+++ b/balances.json
@@ -3,6 +3,6 @@
   "project": "stp",
   "env": "staging",
   "tag": "branch-master",
-  "repo_credentials": "arn:aws:secretsmanager:us-west-2:787588439240:secret:shared-infra-staging-credentials/dockerhub-czisi-PhEla6"
+  "repo_credentials": "arn:aws:secretsmanager:us-east-1:787588439240:secret:stp-staging-credentials/dockerhub-cellxgeneci-MbiE66"
 }
 

--- a/czecs.json
+++ b/czecs.json
@@ -1,16 +1,19 @@
 {
   "Family": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}",
+  "Cpu": "1024",
+  "Memory": "4096",
   "ContainerDefinitions": [
     {
       "name": "cellxgene-rest-api",
       "image": "chanzuckerberg/cellxgene-rest-api:{{ .Values.tag }}",
-      "cpu": 1024,
-      "memoryReservation": 4096,
+      "repositoryCredentials": {
+        "credentialsParameter": "{{ .Values.repo_credentials }}"
+      },
       "essential": true,
       "portMappings": [
         {
           "containerPort": 5000,
-          "hostPort": 0
+          "hostPort": 5000
         }
       ],
       "environment": [
@@ -22,12 +25,17 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "stp-{{ .Values.env }}-ecs",
+          "awslogs-group": "{{ .Values.project }}-{{ .Values.env }}-ecs",
           "awslogs-region": "{{ .Values.region }}",
           "awslogs-stream-prefix": "cellxgene-rest-api"
         }
       }
     }
   ],
-  "TaskRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}"
+  "TaskRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}",
+  "ExecutionRoleArn": "{{ .Values.project }}-{{ .Values.env }}-{{ .Values.name }}-execution-role",
+  "RequiresCompatibilities": [
+    "FARGATE"
+  ],
+  "NetworkMode": "awsvpc"
 }


### PR DESCRIPTION
This PR makes the czecs changes for cellxgene deployments using Fargate. This PR is paired with https://github.com/chanzuckerberg/stp-infra/pull/54.

The PR makes the Fargate task definition changes in the following ways:
* Cpu/Memory must now be defined at the top level instead of just the container level.
* The hostPort number must now match the container port.
* Networking is setup for Fargate compatible awsvpc mode.
* Dockerhub credentials for private Docker repos are now specified in the task instead of being implicitly handled by the underlying ECS instance.